### PR TITLE
Chrome cookies implementation for storing access and refresh token. Update to extension permissions.

### DIFF
--- a/background.js
+++ b/background.js
@@ -11,6 +11,7 @@
 const regexYTVideoURL = new RegExp("https:\/\/www\.youtube\.com\/watch\?\S*");
 
 const DOMAIN_BACKEND = "https://playadd-for-spotify.herokuapp.com";
+const DOMAIN_COOKIE_STORE = "https://playadd-for-spotify.herokuapp.com";
 const DOMAIN_EXTENSION = "chrome-extension://" + chrome.runtime.id;
 
 // The time between refreshing the access token (45 minutes).
@@ -98,8 +99,8 @@ function spotifyLoginAuthorization() {
         let queryParameters = queryURLToJSON(redirectURI);
 
         // Store the tokens into storage.
-        chrome.cookies.set({"httpOnly": true, "name": "access_token", "url": DOMAIN_BACKEND, "value": queryParameters.access_token});
-        chrome.cookies.set({"httpOnly": true, "name": "refresh_token", "url": DOMAIN_BACKEND, "value": queryParameters.refresh_token});
+        chrome.cookies.set({"httpOnly": true, "name": "access_token", "url": DOMAIN_COOKIE_STORE, "value": queryParameters.access_token});
+        chrome.cookies.set({"httpOnly": true, "name": "refresh_token", "url": DOMAIN_COOKIE_STORE, "value": queryParameters.refresh_token});
         chrome.storage.local.set({"login_status": true});
 
         // Set an interval to refresh the access token periodically.
@@ -114,7 +115,7 @@ function spotifyLoginAuthorization() {
  * Refresh the access token using the refresh token.
  */
 function spotifyRefreshToken() {
-    chrome.cookies.get({"name": "refresh_token", "url": DOMAIN_BACKEND}, (cookie) => {
+    chrome.cookies.get({"name": "refresh_token", "url": DOMAIN_COOKIE_STORE}, (cookie) => {
         // Query parameters for making a request to the backend server.
         const refreshEndpoint = DOMAIN_BACKEND + "/api/spotify/refresh/";
         const refreshToken = cookie.value;
@@ -131,10 +132,10 @@ function spotifyRefreshToken() {
                 let response = JSON.parse(xmlHTTP.responseText);
 
                 // Store the tokens into storage.
-                chrome.cookies.set({"httpOnly": true, "name": "access_token", "url": DOMAIN_BACKEND, "value": response.access_token});
+                chrome.cookies.set({"httpOnly": true, "name": "access_token", "url": DOMAIN_COOKIE_STORE, "value": response.access_token});
                 // Sometimes we will also get a new refresh token from Spotify. If so, store the new refresh token.
                 if (response.hasOwnProperty("refresh_token")) {
-                    chrome.cookies.set({"httpOnly": true, "name": "refresh_token", "url": DOMAIN_BACKEND, "value": response.refresh_token});
+                    chrome.cookies.set({"httpOnly": true, "name": "refresh_token", "url": DOMAIN_COOKIE_STORE, "value": response.refresh_token});
                 }
             }
         }

--- a/background.js
+++ b/background.js
@@ -11,6 +11,7 @@
 const regexYTVideoURL = new RegExp("https:\/\/www\.youtube\.com\/watch\?\S*");
 
 const DOMAIN_BACKEND = "https://playadd-for-spotify.herokuapp.com";
+const DOMAIN_EXTENSION = "chrome-extension://" + chrome.runtime.id;
 
 // The time between refreshing the access token (45 minutes).
 const TOKEN_REFRESH_TIME = 2700000;
@@ -97,15 +98,15 @@ function spotifyLoginAuthorization() {
         let queryParameters = queryURLToJSON(redirectURI);
 
         // Store the tokens into storage.
-        chrome.storage.local.set({"access_token": queryParameters.access_token});
-        chrome.storage.local.set({"refresh_token": queryParameters.refresh_token});
+        chrome.cookies.set({"httpOnly": true, "name": "access_token", "url": DOMAIN_BACKEND, "value": queryParameters.access_token});
+        chrome.cookies.set({"httpOnly": true, "name": "refresh_token", "url": DOMAIN_BACKEND, "value": queryParameters.refresh_token});
         chrome.storage.local.set({"login_status": true});
 
         // Set an interval to refresh the access token periodically.
         tokenRefreshInterval = setInterval(spotifyRefreshToken, TOKEN_REFRESH_TIME);
 
         // Open the redirect page to show the user that they have successfully connected their Spotify account.
-        window.open("chrome-extension://" + chrome.runtime.id + "/redirect.html");
+        window.open(DOMAIN_EXTENSION + "/redirect.html");
     });
 }
 
@@ -113,10 +114,10 @@ function spotifyLoginAuthorization() {
  * Refresh the access token using the refresh token.
  */
 function spotifyRefreshToken() {
-    chrome.storage.local.get("refresh_token", (item) => {
+    chrome.cookies.get({"name": "refresh_token", "url": DOMAIN_BACKEND}, (cookie) => {
         // Query parameters for making a request to the backend server.
         const refreshEndpoint = DOMAIN_BACKEND + "/api/spotify/refresh/";
-        const refreshToken = item.refresh_token;
+        const refreshToken = cookie.value;
 
         // Build the request URI.
         const refreshQuery = refreshEndpoint + 
@@ -130,10 +131,10 @@ function spotifyRefreshToken() {
                 let response = JSON.parse(xmlHTTP.responseText);
 
                 // Store the tokens into storage.
-                chrome.storage.local.set({"access_token": response.access_token});
+                chrome.cookies.set({"httpOnly": true, "name": "access_token", "url": DOMAIN_BACKEND, "value": response.access_token});
                 // Sometimes we will also get a new refresh token from Spotify. If so, store the new refresh token.
                 if (response.hasOwnProperty("refresh_token")) {
-                    chrome.storage.local.set({"refresh_token": response.refresh_token});
+                    chrome.cookies.set({"httpOnly": true, "name": "refresh_token", "url": DOMAIN_BACKEND, "value": response.refresh_token});
                 }
             }
         }
@@ -145,7 +146,8 @@ function spotifyRefreshToken() {
  * Removes access and refresh token keys from chrome.storage and changes login status in chrome.storage.
  */
 function spotifyLogout() {
-    chrome.storage.local.remove(["access_token", "refresh_token"]);
+    chrome.cookies.remove({"name": "access_token", "url": DOMAIN_BACKEND});
+    chrome.cookies.remove({"name": "refresh_token", "url": DOMAIN_BACKEND});
     chrome.storage.local.set({"login_status": false});
     clearInterval(tokenRefreshInterval);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
     "name": "PlayAdd for Spotify",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Add YouTube songs to Spotify playlists.",
     "permissions": [
-        "cookies", "identity", "storage", "tabs,",
+        "cookies", "identity", "storage", "tabs",
         "https://www.youtube.com/*", "http://localhost:3000/*", "https://playadd-for-spotify.herokuapp.com/*"],
     "background": {
         "scripts": ["background.js"],

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "Add YouTube songs to Spotify playlists.",
     "permissions": [
-        "tabs", "activeTab", "storage", "webNavigation", "identity", "cookies",
+        "cookies", "identity", "storage", "tabs,",
         "https://www.youtube.com/*", "http://localhost:3000/*", "https://playadd-for-spotify.herokuapp.com/*"],
     "background": {
         "scripts": ["background.js"],

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,9 @@
     "name": "PlayAdd for Spotify",
     "version": "1.0.0",
     "description": "Add YouTube songs to Spotify playlists.",
-    "permissions": ["tabs", "activeTab", "storage", "webNavigation", "identity", "https://www.youtube.com/*", "http://localhost:3000/*", "https://playadd-for-spotify.herokuapp.com/*"],
+    "permissions": [
+        "tabs", "activeTab", "storage", "webNavigation", "identity", "cookies",
+        "https://www.youtube.com/*", "http://localhost:3000/*", "https://playadd-for-spotify.herokuapp.com/*"],
     "background": {
         "scripts": ["background.js"],
         "persistent": false

--- a/popup.js
+++ b/popup.js
@@ -19,6 +19,7 @@ let addButtonElement = document.getElementById("add-button");
 /*--------------------------------------------------------------------------*/
 
 const DOMAIN_BACKEND = "https://playadd-for-spotify.herokuapp.com";
+const DOMAIN_COOKIE_STORE = "https://playadd-for-spotify.herokuapp.com";
 
 /**
  * Makes the entire track panel div clickable. Opens the currently playing song in Spotify.
@@ -76,7 +77,7 @@ function spotifyPlaylistAdd(playlistID, trackURI) {
             "/tracks?uris=" + encodeURIComponent(trackURI) +
             "&position=" + position;
 
-            chrome.cookies.get({"name": "access_token", "url": DOMAIN_BACKEND}, (cookie) => {
+            chrome.cookies.get({"name": "access_token", "url": DOMAIN_COOKIE_STORE}, (cookie) => {
         let xmlHTTP = new XMLHttpRequest();
         xmlHTTP.open("POST", addURL, true);
         xmlHTTP.setRequestHeader("Authorization", "Bearer " + cookie.value);
@@ -101,7 +102,7 @@ function spotifySearch(title) {
             "&type=" + type + 
             "&limit=" + limit;
     
-            chrome.cookies.get({"name": "access_token", "url": DOMAIN_BACKEND}, (cookie) => {
+            chrome.cookies.get({"name": "access_token", "url": DOMAIN_COOKIE_STORE}, (cookie) => {
         let xmlHTTP = new XMLHttpRequest();
         xmlHTTP.open("GET", searchURL, true);
         xmlHTTP.setRequestHeader("Authorization", "Bearer " + cookie.value);
@@ -157,7 +158,7 @@ function spotifyUpdateUI(coverURL, song, artist) {
 function spotifyGetUserURI(callbackGetPlaylists, callbackUpdateUI) {
     const userEndpoint = "https://api.spotify.com/v1/me";
     
-    chrome.cookies.get({"name": "access_token", "url": DOMAIN_BACKEND}, (cookie) => {
+    chrome.cookies.get({"name": "access_token", "url": DOMAIN_COOKIE_STORE}, (cookie) => {
         let xmlHTTP = new XMLHttpRequest();
         xmlHTTP.open("GET", userEndpoint, true);
         xmlHTTP.setRequestHeader("Authorization", "Bearer " + cookie.value);
@@ -185,7 +186,7 @@ function spotifyGetUserPlaylists(userURI, callbackUpdateUI) {
     // Build the request URI.
     const playlistsQuery = playlistsEndpoint;
     
-    chrome.cookies.get({"name": "access_token", "url": DOMAIN_BACKEND}, (cookie) => {
+    chrome.cookies.get({"name": "access_token", "url": DOMAIN_COOKIE_STORE}, (cookie) => {
         let xmlHTTP = new XMLHttpRequest();
         xmlHTTP.open("GET", playlistsQuery, true);
         xmlHTTP.setRequestHeader("Authorization", "Bearer " + cookie.value);

--- a/popup.js
+++ b/popup.js
@@ -14,6 +14,12 @@ let trackPanelElement = document.getElementById("track-panel");
 let userPlaylistsElement = document.getElementById("playlists-dropdown");
 let addButtonElement = document.getElementById("add-button");
 
+/*--------------------------------------------------------------------------*/
+/* CONSTANTS/GLOBAL VARIABLES */
+/*--------------------------------------------------------------------------*/
+
+const DOMAIN_BACKEND = "https://playadd-for-spotify.herokuapp.com";
+
 /**
  * Makes the entire track panel div clickable. Opens the currently playing song in Spotify.
  */
@@ -70,10 +76,10 @@ function spotifyPlaylistAdd(playlistID, trackURI) {
             "/tracks?uris=" + encodeURIComponent(trackURI) +
             "&position=" + position;
 
-    chrome.storage.local.get("access_token", (item) => {
+            chrome.cookies.get({"name": "access_token", "url": DOMAIN_BACKEND}, (cookie) => {
         let xmlHTTP = new XMLHttpRequest();
         xmlHTTP.open("POST", addURL, true);
-        xmlHTTP.setRequestHeader("Authorization", "Bearer " + item.access_token);
+        xmlHTTP.setRequestHeader("Authorization", "Bearer " + cookie.value);
         xmlHTTP.onreadystatechange = () => {
             if (xmlHTTP.readyState === 4 && xmlHTTP.status === 201) {
                 alert("Added to playlist!");
@@ -95,10 +101,10 @@ function spotifySearch(title) {
             "&type=" + type + 
             "&limit=" + limit;
     
-    chrome.storage.local.get("access_token", (item) => {
+            chrome.cookies.get({"name": "access_token", "url": DOMAIN_BACKEND}, (cookie) => {
         let xmlHTTP = new XMLHttpRequest();
         xmlHTTP.open("GET", searchURL, true);
-        xmlHTTP.setRequestHeader("Authorization", "Bearer " + item.access_token);
+        xmlHTTP.setRequestHeader("Authorization", "Bearer " + cookie.value);
         xmlHTTP.onreadystatechange = () => {
             if (xmlHTTP.readyState === 4 && xmlHTTP.status === 200) {
                 if (JSON.parse(xmlHTTP.responseText).tracks.items.length === 0) {
@@ -151,10 +157,10 @@ function spotifyUpdateUI(coverURL, song, artist) {
 function spotifyGetUserURI(callbackGetPlaylists, callbackUpdateUI) {
     const userEndpoint = "https://api.spotify.com/v1/me";
     
-    chrome.storage.local.get("access_token", (item) => {
+    chrome.cookies.get({"name": "access_token", "url": DOMAIN_BACKEND}, (cookie) => {
         let xmlHTTP = new XMLHttpRequest();
         xmlHTTP.open("GET", userEndpoint, true);
-        xmlHTTP.setRequestHeader("Authorization", "Bearer " + item.access_token);
+        xmlHTTP.setRequestHeader("Authorization", "Bearer " + cookie.value);
         xmlHTTP.onreadystatechange = () => {
             if (xmlHTTP.readyState === 4 && xmlHTTP.status === 200) {
                 let userURI = JSON.parse(xmlHTTP.response).uri;
@@ -179,10 +185,10 @@ function spotifyGetUserPlaylists(userURI, callbackUpdateUI) {
     // Build the request URI.
     const playlistsQuery = playlistsEndpoint;
     
-    chrome.storage.local.get("access_token", (item) => {
+    chrome.cookies.get({"name": "access_token", "url": DOMAIN_BACKEND}, (cookie) => {
         let xmlHTTP = new XMLHttpRequest();
         xmlHTTP.open("GET", playlistsQuery, true);
-        xmlHTTP.setRequestHeader("Authorization", "Bearer " + item.access_token);
+        xmlHTTP.setRequestHeader("Authorization", "Bearer " + cookie.value);
         xmlHTTP.onreadystatechange = () => {
             if (xmlHTTP.readyState === 4 && xmlHTTP.status === 200) {
                 // An array of all playlists the user has (including ones they only follow).

--- a/settings.js
+++ b/settings.js
@@ -13,6 +13,11 @@ const spotifyButtonElement = document.getElementById("spotify-button");
 
 const extensionVersionElement = document.getElementById("extension-version-text");
 
+/*--------------------------------------------------------------------------*/
+/* CONSTANTS/GLOBAL VARIABLES */
+/*--------------------------------------------------------------------------*/
+const DOMAIN_BACKEND = "https://playadd-for-spotify.herokuapp.com";
+
 /**
  * Tell the background.js script to start the login process or to logout the user, depending
  * on the current login status of the user.
@@ -89,10 +94,10 @@ function setUIUserIsLoggedOut() {
 function spotifyGetEmail(callback) {
     const profileEndpoint = "https://api.spotify.com/v1/me";
 
-    chrome.storage.local.get("access_token", (item) => {
+    chrome.cookies.get({"name": "access_token", "url": DOMAIN_BACKEND}, (cookie) => {
         let xmlHTTP = new XMLHttpRequest();
         xmlHTTP.open("GET", profileEndpoint, true);
-        xmlHTTP.setRequestHeader("Authorization", "Bearer " + item.access_token);
+        xmlHTTP.setRequestHeader("Authorization", "Bearer " + cookie.value);
         xmlHTTP.onreadystatechange = () => {
             if (xmlHTTP.readyState === 4 && xmlHTTP.status === 200) {
                 let userObject = JSON.parse(xmlHTTP.response);

--- a/settings.js
+++ b/settings.js
@@ -16,7 +16,9 @@ const extensionVersionElement = document.getElementById("extension-version-text"
 /*--------------------------------------------------------------------------*/
 /* CONSTANTS/GLOBAL VARIABLES */
 /*--------------------------------------------------------------------------*/
+
 const DOMAIN_BACKEND = "https://playadd-for-spotify.herokuapp.com";
+const DOMAIN_COOKIE_STORE = "https://playadd-for-spotify.herokuapp.com";
 
 /**
  * Tell the background.js script to start the login process or to logout the user, depending
@@ -94,7 +96,7 @@ function setUIUserIsLoggedOut() {
 function spotifyGetEmail(callback) {
     const profileEndpoint = "https://api.spotify.com/v1/me";
 
-    chrome.cookies.get({"name": "access_token", "url": DOMAIN_BACKEND}, (cookie) => {
+    chrome.cookies.get({"name": "access_token", "url": DOMAIN_COOKIE_STORE}, (cookie) => {
         let xmlHTTP = new XMLHttpRequest();
         xmlHTTP.open("GET", profileEndpoint, true);
         xmlHTTP.setRequestHeader("Authorization", "Bearer " + cookie.value);


### PR DESCRIPTION
- Moved storing access and refresh tokens in chrome.storage.local to HTTP cookies in chrome.cookies found in the Heroku domain.
- Removed unnecessary permissions from manifest.